### PR TITLE
Add CDNJS version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/veltman/flubber.svg?branch=master)](https://travis-ci.org/veltman/flubber)
+[![CDNJS](https://img.shields.io/cdnjs/v/flubber.svg)](https://cdnjs.com/libraries/flubber)
 
 # flubber
 


### PR DESCRIPTION
The badge shows the latest lib version on CDNJS and gives a link of it.